### PR TITLE
Javdoc Error in JDK 8

### DIFF
--- a/card.io/build.gradle
+++ b/card.io/build.gradle
@@ -114,7 +114,10 @@ android.libraryVariants.all { variant ->
                 variantCompiledClassesDir,
                 project.plugins.findPlugin("com.android.library").bootClasspath
         )
-
+        
+        if (JavaVersion.current().isJava8Compatible()) {
+		    options.addStringOption('Xdoclint:none', '-quiet')
+	    }
         include 'io/card/payment/*.java'
 
         // More info on options here: http://www.gradle.org/docs/current/javadoc/org/gradle/external/javadoc/StandardJavadocDocletOptions.html


### PR DESCRIPTION
Add Xdoclint:none to javadoc task when the source is built using jdk 8.