### PR TITLE
Added intent extra to scan activity to allow defaulting to manual entry

### DIFF
--- a/SampleApp/src/main/java/org/my/scanExample/MyScanActivity.java
+++ b/SampleApp/src/main/java/org/my/scanExample/MyScanActivity.java
@@ -61,6 +61,10 @@ public class MyScanActivity extends Activity {
         // matches the theme of your application
         scanIntent.putExtra(CardIOActivity.EXTRA_KEEP_APPLICATION_THEME, false); // default: false
 
+        // defaults to manual entry
+        // if set, when activity is started will display manual entry screen
+        scanIntent.putExtra(CardIOActivity.EXTRA_DEFAULT_TO_MANUAL_ENTRY, false); // default: false
+
         // MY_SCAN_REQUEST_CODE is arbitrary and is only used within this activity.
         startActivityForResult(scanIntent, MY_SCAN_REQUEST_CODE);
     }

--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -199,6 +199,14 @@ public final class CardIOActivity extends Activity {
      */
     public static final String EXTRA_KEEP_APPLICATION_THEME = "io.card.payment.keepApplicationTheme";
 
+    /**
+     * Boolean extra. Optional. Defaults to <code>false</code>. Defaults to manual entry instead of
+     * scanning card.
+     * <br><br>
+     * If {@link #EXTRA_SUPPRESS_MANUAL_ENTRY} is true this will be ignored.
+     */
+    public static final String EXTRA_DEFAULT_TO_MANUAL_ENTRY = "io.card.payment.defaultToManual";
+
 
     /**
      * Boolean extra. Used for testing only.
@@ -282,6 +290,7 @@ public final class CardIOActivity extends Activity {
     private CardScanner mCardScanner;
 
     private boolean manualEntryFallbackOrForced = false;
+    private boolean nextActivityOnResume = false;
 
     /**
      * Static variable for the decorated card image. This is ugly, but works. Parceling and
@@ -342,6 +351,8 @@ public final class CardIOActivity extends Activity {
         if (clientData.getBooleanExtra(EXTRA_NO_CAMERA, false)) {
             Log.i(Util.PUBLIC_LOG_TAG, "EXTRA_NO_CAMERA set to true. Skipping camera.");
             manualEntryFallbackOrForced = true;
+        } else if (clientData.getBooleanExtra(EXTRA_DEFAULT_TO_MANUAL_ENTRY, false)) {
+            nextActivityOnResume = true;
         } else {
             try {
                 if (!Util.hardwareSupported()) {
@@ -507,7 +518,8 @@ public final class CardIOActivity extends Activity {
         super.onResume();
         Log.i(TAG, "onResume() ----------------------------------------------------------");
 
-        if (manualEntryFallbackOrForced) {
+        if (manualEntryFallbackOrForced || (nextActivityOnResume && !suppressManualEntry)) {
+            nextActivityOnResume = false;
             nextActivity();
             return;
         }


### PR DESCRIPTION
Addressing an issue I posted: https://github.com/card-io/card.io-Android-SDK/issues/73

Adding new extra: ```EXTRA_DEFAULT_TO_MANUAL_ENTRY ``` for defaulting to manual entry screen

Tested ```SampleApp``` on my Nexus 5 running 5.1.1 (API 22)

Setting ```EXTRA_DEFAULT_TO_MANUAL_ENTRY ``` will show manual entry screen when ```CardIOActivity``` is started, however a potential usability issue I see is that there is no scan button on the manual entry screen.  So when the user presses back it will go to scan screen as is, which may not be the best user experience.  Any suggestions on this?