### PR TITLE
Add null check on permission denied code path.

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -846,8 +846,10 @@ public final class CardIOActivity extends Activity {
         final Intent origIntent = getIntent();
         if (origIntent != null && origIntent.getBooleanExtra(EXTRA_SUPPRESS_CONFIRMATION, false)) {
             Intent dataIntent = new Intent(CardIOActivity.this, DataEntryActivity.class);
-            dataIntent.putExtra(EXTRA_SCAN_RESULT, mDetectedCard);
-            mDetectedCard = null;
+            if (mDetectedCard != null) {
+                dataIntent.putExtra(EXTRA_SCAN_RESULT, mDetectedCard);
+                mDetectedCard = null;
+            }
 
             Util.writeCapturedCardImageIfNecessary(origIntent, dataIntent, mOverlay);
 


### PR DESCRIPTION
- Currently, a null EXTRA_SCAN_RESULT will be returned if user select
deny on camera permission. This could confuse library users. As in sample code,
no null check is needed.