### PR TITLE
fix issue with Nexus 5X camera upside down

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardScanner.java
+++ b/card.io/src/main/java/io/card/payment/CardScanner.java
@@ -11,7 +11,9 @@ import android.graphics.Rect;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
 import android.hardware.Camera.Size;
+import android.os.Build;
 import android.util.Log;
+import android.view.Surface;
 import android.view.SurfaceHolder;
 
 import java.io.IOException;
@@ -222,7 +224,7 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
                 Log.v(TAG, "camera is connected");
             }
 
-            mCamera.setDisplayOrientation(90);
+            setCameraDisplayOrientation(mCamera);
 
             Camera.Parameters parameters = mCamera.getParameters();
 
@@ -614,5 +616,50 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
             }
         }
         return false;
+    }
+
+    private void setCameraDisplayOrientation(Camera mCamera) {
+        int result;
+
+        /* check API level. If upper API level 21, re-calculate orientation. */
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            android.hardware.Camera.CameraInfo info =
+                    new android.hardware.Camera.CameraInfo();
+            android.hardware.Camera.getCameraInfo(0, info);
+            int rotation = getDeviceOrientation();
+
+            int degrees = 0;
+            switch (rotation) {
+                case Surface.ROTATION_0:
+                    degrees = 0;
+                    break;
+                case Surface.ROTATION_90:
+                    degrees = 90;
+                    break;
+                case Surface.ROTATION_180:
+                    degrees = 180;
+                    break;
+                case Surface.ROTATION_270:
+                    degrees = 270;
+                    break;
+            }
+
+            int cameraOrientation = info.orientation + 90;
+            if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                /* compensate the mirror */
+                result = (cameraOrientation + degrees) % 360;
+                result = (360 - result) % 360;
+            } else {
+                result = (cameraOrientation - degrees + 360) % 360;
+            }
+
+        } else {
+            /* if API level is lower than 21, use the default value */
+            result = 90;
+        }
+
+        /*set display orientation*/
+        mCamera.setDisplayOrientation(result);
     }
 }


### PR DESCRIPTION
- the issue with nexus 5x camera refers to the issue report: https://github.com/card-io/card.io-Android-SDK/issues/91 
- the bug is due to the incompatibility between old Camera API and some new devices with API level 21 and upper. Refer to http://9to5google.com/2015/11/07/why-are-images-nexus-5x-upside-down/
- fix this bug by recalculating and setting camera orientation. The code mainly comes from @MitekDev-ASingal 's comment. This is a temporary fix. The related code might need to be updated to [Camera2](http://developer.android.com/reference/android/hardware/camera2/package-summary.html) in the future.
- I tested the code on three devices with different Android versions:
  * Nexus 5x with AOSP 6.0. Its camera will be upside down on previous SDK.
  * Nexus 4 with AOSP 5.1.1. Its camera performs well on previous card.io SDK.
  * Nexus 4 with CM 11(Android 4.4). Its camera works normally.
  * LG G3 with CM 12. Its camera works well.

