### PR TITLE
Added intent to force manual entry and way for user to return to scanner from manual entry

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -26,7 +26,6 @@ import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.OrientationEventListener;
-import android.view.Surface;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
@@ -209,6 +208,15 @@ public final class CardIOActivity extends Activity {
 
 
     /**
+     * Boolean extra. Optional. Defaults to <code>false</code>. Defaults to manual entry instead of
+     * scanning card.
+     * <br><br>
+     * If {@link #EXTRA_SUPPRESS_MANUAL_ENTRY} is true this will be ignored.
+     */
+    public static final String EXTRA_DEFAULT_TO_MANUAL_ENTRY = "io.card.payment.defaultToManual";
+
+
+    /**
      * Boolean extra. Used for testing only.
      */
     static final String PRIVATE_EXTRA_CAMERA_BYPASS_TEST_MODE = "io.card.payment.cameraBypassTestMode";
@@ -293,6 +301,7 @@ public final class CardIOActivity extends Activity {
     private CardScanner mCardScanner;
 
     private boolean manualEntryFallbackOrForced = false;
+    private boolean nextActivityOnResume = false;
 
     /**
      * Static variable for the decorated card image. This is ugly, but works. Parceling and
@@ -360,6 +369,9 @@ public final class CardIOActivity extends Activity {
             Log.i(Util.PUBLIC_LOG_TAG, "EXTRA_NO_CAMERA set to true. Skipping camera.");
             manualEntryFallbackOrForced = true;
         } else {
+            if (clientData.getBooleanExtra(EXTRA_DEFAULT_TO_MANUAL_ENTRY, false)) {
+                nextActivityOnResume = true;
+            }
             try {
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
                     if(!waitingForPermission) {
@@ -556,7 +568,8 @@ public final class CardIOActivity extends Activity {
         Log.i(TAG, "onResume()");
 
         if(!waitingForPermission) {
-            if (manualEntryFallbackOrForced) {
+            if (manualEntryFallbackOrForced || (nextActivityOnResume && !suppressManualEntry)) {
+                nextActivityOnResume = false;
                 nextActivity();
                 return;
             }

--- a/card.io/src/main/java/io/card/payment/DataEntryActivity.java
+++ b/card.io/src/main/java/io/card/payment/DataEntryActivity.java
@@ -19,6 +19,8 @@ import android.text.method.DateKeyListener;
 import android.text.method.DigitsKeyListener;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
@@ -472,6 +474,25 @@ public final class DataEntryActivity extends Activity implements TextWatcher {
         }
 
         Log.i(TAG, "ready for manual entry"); // used by tests. don't delete.
+    }
+
+    // TODO need to localize title "Camera"
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuItem item = menu.add("Camera");
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
+            item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getTitle().equals("Camera")) {
+            finish();
+        }
+        return true;
     }
 
     private EditText advanceToNextEmptyField() {


### PR DESCRIPTION
WIP - Creating placeholder PR, still need to test more, tested on device (Samsung Galaxy S4 4.4.4 API 19), if anyone has more devices to test with will be helpful

This matches functionality in iOS PR: https://github.com/card-io/card.io-iOS-source/pull/52

Need input on UI additions to ```DataEntryActivity```, added a options menu item titled 'Camera' which shows up in the action bar on API 11+ and returns the user to the ```CardIOActivity```

Also need assistance localizing the options item in ```DataEntryActivity``` on lines 483 and 492, not sure how your localization mechanism works it's not the standard strings.xml