### PR TITLE
Add proguard consumer file configuration

### DIFF
--- a/card.io/build.gradle
+++ b/card.io/build.gradle
@@ -30,6 +30,8 @@ android {
         buildConfigField "String", "PRODUCT_VERSION", "\"${product_version}\""
         buildConfigField "String", "BUILD_TIME", "\"${build_time}\""
 
+        consumerProguardFiles 'release-proguard.cfg'
+
         testApplicationId 'io.card.development'
     }
 

--- a/card.io/release-proguard.cfg
+++ b/card.io/release-proguard.cfg
@@ -1,0 +1,6 @@
+# Proguard configuration for the release mode.
+
+-keep class io.card.**
+-keepclassmembers class io.card.** {
+    *;
+}


### PR DESCRIPTION
This PR adds the proguard consumer configuration file. 

Since the library is provided in the aar format, the proguard rules should be included directly in the aar using the consumer proguard file directive available at the build gradle file.

Closes https://github.com/card-io/card.io-Android-SDK/issues/112 and [this](https://github.com/card-io/card.io-Android-SDK#note-before-you-build-in-release-mode-make-sure-to-adjust-your-proguard-configuration-by-adding-the-following-to-proguardcnf) can be removed.