### PR TITLE
Disables Card Scanning if missing processor files

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -366,6 +366,9 @@ public final class CardIOActivity extends Activity {
         if (clientData.getBooleanExtra(EXTRA_NO_CAMERA, false)) {
             Log.i(Util.PUBLIC_LOG_TAG, "EXTRA_NO_CAMERA set to true. Skipping camera.");
             manualEntryFallbackOrForced = true;
+        } else if (!CardScanner.processorSupported()){
+            Log.i(Util.PUBLIC_LOG_TAG, "Processor not Supported. Skipping camera.");
+            manualEntryFallbackOrForced = true;
         } else {
             try {
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {


### PR DESCRIPTION
- In cases where the .so files are missing.
- Fixes [PayPal-Android-SDK#279](https://github.com/paypal/PayPal-Android-SDK/issues/279).

### Steps to test:

- In SampleApp/build.gradle, add the following to `android` node:

```
packagingOptions {
        exclude 'lib/arm64-v8a/libcardioDecider.so'
        exclude 'lib/arm64-v8a/libcardioRecognizer.so'
        exclude 'lib/arm64-v8a/libcardioRecognizer_tegra2.so'
        exclude 'lib/arm64-v8a/libopencv_core.so'
        exclude 'lib/arm64-v8a/libopencv_imgproc.so'
        exclude 'lib/armeabi/libcardioDecider.so'
        exclude 'lib/armeabi-v7a/libcardioDecider.so'
        exclude 'lib/armeabi-v7a/libcardioRecognizer.so'
        exclude 'lib/armeabi-v7a/libcardioRecognizer_tegra2.so'
        exclude 'lib/armeabi-v7a/libopencv_core.so'
        exclude 'lib/armeabi-v7a/libopencv_imgproc.so'
        exclude 'lib/mips/libcardioDecider.so'
        exclude 'lib/x86/libcardioDecider.so'
        exclude 'lib/x86/libcardioRecognizer.so'
        exclude 'lib/x86/libcardioRecognizer_tegra2.so'
        exclude 'lib/x86/libopencv_core.so'
        exclude 'lib/x86/libopencv_imgproc.so'
        exclude 'lib/x86_64/libcardioDecider.so'
        exclude 'lib/x86_64/libcardioRecognizer.so'
        exclude 'lib/x86_64/libcardioRecognizer_tegra2.so'
        exclude 'lib/x86_64/libopencv_core.so'
        exclude 'lib/x86_64/libopencv_imgproc.so'
    }
```

Run the sampleApp. It should automatically skip card scanning and open input form. 

- NOTE: If you already have sample app installed, make sure to remove camera permission first, and test it.