### PR TITLE
Handle runtime permissions when checking hardware support

### DIFF
--- a/card.io/src/main/java/io/card/payment/Util.java
+++ b/card.io/src/main/java/io/card/payment/Util.java
@@ -84,8 +84,12 @@ class Util {
         try {
             c = Camera.open();
         } catch (RuntimeException e) {
-            Log.w(PUBLIC_LOG_TAG, "- Error opening camera: " + e);
-            throw new CameraUnavailableException();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                return true;
+            } else {
+                Log.w(PUBLIC_LOG_TAG, "- Error opening camera: " + e);
+                throw new CameraUnavailableException();
+            }
         }
         if (c == null) {
             Log.w(PUBLIC_LOG_TAG, "- No camera found");


### PR DESCRIPTION
Return true for `CardIOActivity#canReadCardWithCamera` when camera cannot be access on API >= 23.

Fixes card-io/card.io-Android-SDK#136