### PR TITLE
Adds Support For Loading Native Libraries From Alternative Path

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIONativeLibsConfig.java
+++ b/card.io/src/main/java/io/card/payment/CardIONativeLibsConfig.java
@@ -1,0 +1,24 @@
+package io.card.payment;
+
+/* CardIONativeLibsConfig.java
+ * See the file "LICENSE.md" for the full license governing this code.
+ */
+
+/**
+ * A config class that is used to specify an alternative search path for the native libraries.
+ *
+ * It's primary use case is for when the libraries are loaded over the network instead of being
+ * shipped with the APK and are stored in the app's data folder.
+ */
+public class CardIONativeLibsConfig {
+
+    private static String alternativeLibsPath;
+
+    public static void init(String path) {
+        alternativeLibsPath = path;
+    }
+
+    static String getAlternativeLibsPath() {
+        return alternativeLibsPath;
+    }
+}

--- a/card.io/src/main/java/io/card/payment/CardIONativeLibsConfig.java
+++ b/card.io/src/main/java/io/card/payment/CardIONativeLibsConfig.java
@@ -7,7 +7,7 @@ package io.card.payment;
 /**
  * A config class that is used to specify an alternative search path for the native libraries.
  *
- * It's primary use case is for when the libraries are loaded over the network instead of being
+ * Its primary use case is for when the libraries are loaded over the network instead of being
  * shipped with the APK and are stored in the app's data folder.
  */
 public class CardIONativeLibsConfig {


### PR DESCRIPTION
Summary: In order to support not shipping the native libraries
with an APK and instead downloading the architecture specific
.so files from the network and storing them in an app's data
folder, this adds support for setting an alternative lib search
path via the `CardIONativeLibsConfig`.

Test Plan:
 - Verified that manual entry screen is displayed when native libs are not downloaded / available.
 - Verified that setting the alterantive path works and the camera screen is shown.