### PR TITLE
fix : camera permission grant https://github.com/card-io/card.io-Andr…

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -656,7 +656,7 @@ public final class CardIOActivity extends Activity {
                     manualEntryFallbackOrForced = true;
                     // show manual entry - handled in onResume()
                 }
-                onResume();
+                // onResume() will be called as part of the activity lifecycle, no need to call it
             }
         }
     }


### PR DESCRIPTION
On Android 6 + there is a check for the camera permission onCreate. This pauses the activity. After the permission handling part onResume was invoked. But another call was done to onResume as the activity actually resumed.
 
https://github.com/card-io/card.io-Android-SDK/issues/150