### PR TITLE
Fix AndroidRuntimeException: requestFeature() must be called before a…

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -324,8 +324,6 @@ public final class CardIOActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
         numActivityAllocations++;
         // NOTE: java native asserts are disabled by default on Android.
         if (numActivityAllocations != 1) {
@@ -399,6 +397,7 @@ public final class CardIOActivity extends Activity {
             }
         }
 
+        super.onCreate(savedInstanceState);
     }
 
     private void android23AndAboveHandleCamera() {


### PR DESCRIPTION
…dding content

On Android devices API level <=22 requestFeature() call is made after calling
super.onCreate() which raises an Exception.