### PR TITLE
Fix camera preview not showing on first launch

### DIFF
--- a/card.io/src/main/java/io/card/payment/CardIOActivity.java
+++ b/card.io/src/main/java/io/card/payment/CardIOActivity.java
@@ -656,7 +656,7 @@ public final class CardIOActivity extends Activity {
                     manualEntryFallbackOrForced = true;
                     // show manual entry - handled in onResume()
                 }
-                onResume();
+                // onResume() will be called as part of the activity lifecycle, no need to call it
             }
         }
     }

--- a/card.io/src/main/java/io/card/payment/CardScanner.java
+++ b/card.io/src/main/java/io/card/payment/CardScanner.java
@@ -73,7 +73,7 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
     private native void nGetGuideFrame(int orientation, int previewWidth, int previewHeight, Rect r);
 
     private native void nScanFrame(byte[] data, int frameWidth, int frameHeight, int orientation,
-                                   DetectionInfo dinfo, Bitmap resultBitmap, boolean scanExpiry);
+            DetectionInfo dinfo, Bitmap resultBitmap, boolean scanExpiry);
 
     private native int nGetNumFramesScanned();
 
@@ -106,7 +106,7 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
     // accessed by test harness subclass.
     protected boolean useCamera = true;
 
-    private boolean isSurfaceValid;
+    private boolean isPreviewInit;
 
     private int numManualRefocus;
     private int numAutoRefocus;
@@ -318,7 +318,7 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
             mCamera.setPreviewCallbackWithBuffer(this);
         }
 
-        if (isSurfaceValid) {
+        if (holder.getSurface().isValid()) {
             makePreviewGo(holder);
         }
 
@@ -362,10 +362,15 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
      * --------------------------- SurfaceHolder callbacks
      */
 
-    private boolean makePreviewGo(SurfaceHolder holder) {
+    private void makePreviewGo(SurfaceHolder holder) {
         // method name from http://www.youtube.com/watch?v=-WmGvYDLsj4
+        if (isPreviewInit) {
+            return;
+        }
         assert holder != null;
         assert holder.getSurface() != null;
+
+        isPreviewInit = true;
         mFirstPreviewFrame = true;
 
         if (useCamera) {
@@ -373,17 +378,14 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
                 mCamera.setPreviewDisplay(holder);
             } catch (IOException e) {
                 Log.e(Util.PUBLIC_LOG_TAG, "can't set preview display", e);
-                return false;
             }
             try {
                 mCamera.startPreview();
                 mCamera.autoFocus(this);
             } catch (RuntimeException e) {
                 Log.e(Util.PUBLIC_LOG_TAG, "startPreview failed on camera. Error: ", e);
-                return false;
             }
         }
-        return true;
     }
 
     /*
@@ -393,7 +395,6 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
     public void surfaceCreated(SurfaceHolder holder) {
         // The Surface has been created, acquire the camera and tell it where to draw.
         if (mCamera != null || !useCamera) {
-            isSurfaceValid = true;
             makePreviewGo(holder);
         } else {
             Log.wtf(Util.PUBLIC_LOG_TAG, "CardScanner.surfaceCreated() - camera is null!");
@@ -423,7 +424,6 @@ class CardScanner implements Camera.PreviewCallback, Camera.AutoFocusCallback,
                 Log.e(Util.PUBLIC_LOG_TAG, "error stopping camera", e);
             }
         }
-        isSurfaceValid = false;
     }
 
     /**


### PR DESCRIPTION
The preview appears once the surface is created and there is a callback for that. Except that the callback is registered in prepareScanner and this is called after the SurfaceView is actually created.
So what I am doing is checking in the resumeScanning if the SurfaceView is valid.

https://github.com/card-io/card.io-Android-SDK/issues/189