### PR TITLE
Update gradle plugin and build tools

### DIFF
--- a/SampleApp/build.gradle
+++ b/SampleApp/build.gradle
@@ -1,9 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 
@@ -12,13 +16,17 @@ repositories {
     maven {
         url "https://jitpack.io"
     }
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "io.card.development"
@@ -37,24 +45,23 @@ android {
     }
 
     android.applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def outputFile = output.outputFile
-            if (outputFile != null && outputFile.name.endsWith('.apk')) {
-                output.outputFile = new File(outputFile.parent, "card.io-sample-app-${variant.name}.apk")
-            }
+        variant.outputs.all { output ->
+            def fileNaming = "apk/"
+            outputFileName = "${fileNaming}card.io-sample-app-${variant.name}.apk";
         }
     }
+
 }
 
 dependencies {
     if (parent != null) {
-        compile project(':card.io')
+        implementation project(':card.io')
     } else {
-        compile 'io.card:android-sdk:REPLACE_VERSION'
+        implementation 'io.card:android-sdk:REPLACE_VERSION'
     }
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.4'
 
-    androidTestCompile "com.android.support.test.espresso:espresso-core:2.2.2"
-    androidTestCompile "com.github.lkorth:device-automator:01d85912ec"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:2.2.2"
+    androidTestImplementation "com.github.lkorth:device-automator:01d85912ec"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
     }
 }

--- a/card.io/build.gradle
+++ b/card.io/build.gradle
@@ -9,7 +9,6 @@ repositories {
 
 android {
     compileSdkVersion rootProject.ext.sdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 16
@@ -31,11 +30,12 @@ android {
             path 'src/main/jni/Android.mk'
         }
     }
+    buildToolsVersion '27.0.3'
 }
 
 dependencies {
-    testCompile "junit:junit:4.12"
-    testCompile "org.robolectric:robolectric:3.1.2"
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.robolectric:robolectric:3.1.2"
 }
 
 task javadocs(type: Javadoc) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 14 15:49:42 EDT 2017
+#Thu Aug 02 10:33:31 BRT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Current code on master does not compile in the latest Android Studio version, this PR updates the gradle plugin, build tools and modify the way that the APK name is generated to be in conformity with the latest gradle plugin.